### PR TITLE
Add {'type': 'Catalog'} and {'type':'Collection'} fields

### DIFF
--- a/stac/pangeo-forge-catalog.json
+++ b/stac/pangeo-forge-catalog.json
@@ -1,4 +1,5 @@
 {
+    "type": "Catalog",
     "stac_version": "1.0.0",
     "id": "pangeo-forge-catalog",
     "title": "Pangeo Forge Catalog",

--- a/stac/swot-adac/GIGATL/gigatl-collection.json
+++ b/stac/swot-adac/GIGATL/gigatl-collection.json
@@ -1,4 +1,5 @@
 {
+    "type": "Collection",
     "stac_version": "1.0.0",
     "id": "GIGATL",
     "title": "GIGATL",

--- a/stac/swot-adac/swot-adac-catalog.json
+++ b/stac/swot-adac/swot-adac-catalog.json
@@ -1,4 +1,5 @@
 {
+    "type": "Catalog",
     "stac_version": "1.0.0",
     "id": "swot-adac",
     "title": "SWOT Adopt-A-Crossover",


### PR DESCRIPTION
Per feedback from @duckontheweb, we were missing the `"type"` fields for our Catalogs and Collections, which is now required as part of the STAC 1.0.0 spec. I'm wondering if this may be the reason STAC Browser has been categorizing [/swot-adac/GIGATL/gigatl-collection.json](https://github.com/pangeo-forge/pangeo-forge-catalog/blob/dev/stac/swot-adac/GIGATL/gigatl-collection.json) as a Catalog:

<img width="896" alt="Screen Shot 2021-07-29 at 12 35 38 PM" src="https://user-images.githubusercontent.com/62192187/127554973-977eb926-ff8a-4e7a-911b-5056f2418aa3.png">